### PR TITLE
Adding functional extensionality to Dafny

### DIFF
--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1386,3 +1386,5 @@ axiom (forall f: HandleType, g: HandleType ::
   Fun#Equal(f, g) <==> f == g);
 
 function $EmptyReads(HandleType): bool;
+
+// -------------------------------------------------------------------------

--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1379,8 +1379,10 @@ axiom (forall x, y, z: int ::
 // -- Function equality and Functional extensionality
 // -------------------------------------------------------------------------
 
-function Fun#Equal(HandleType, HandleType) : bool;
+function Fun#Equal(HandleType, HandleType): bool;
 
 axiom (forall f: HandleType, g: HandleType ::
   { Fun#Equal(f, g) }
   Fun#Equal(f, g) <==> f == g);
+
+function $EmptyReads(HandleType): bool;

--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -181,13 +181,14 @@ axiom (forall<T> v : T, t : Ty, h : Heap ::
     ( $IsAllocBox($Box(v), t, h) <==> $IsAlloc(v,t,h) ));
 
 // ---------------------------------------------------------------
-// -- Is, IsAlloc, and Arity -------------------------------------
+// -- Is, IsAlloc, IsGoodHandle, and Arity -----------------------
 // ---------------------------------------------------------------
 
 // Type-argument to $Is is the /representation type/,
 // the second value argument to $Is is the actual type.
 function $Is<T>(T,Ty): bool;           // no heap for now
 function $IsAlloc<T>(T,Ty,Heap): bool;
+function $IsGoodHandle(HandleType): bool;
 function $Arity(HandleType): int;
 
 // Corresponding entries for boxes...

--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1376,3 +1376,11 @@ axiom (forall x, y, z: int ::
 #endif
 
 // -------------------------------------------------------------------------
+// -- Function equality and Functional extensionality
+// -------------------------------------------------------------------------
+
+function Fun#Equal(HandleType, HandleType) : bool;
+
+axiom (forall f: HandleType, g: HandleType ::
+  { Fun#Equal(f, g) }
+  Fun#Equal(f, g) <==> f == g);

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -1140,6 +1140,8 @@ namespace Microsoft.Dafny {
         return FunctionCall(tok, BuiltinFunction.SeqEqual, null, e0, e1);
       } else if (type.IsIndDatatype) {
         return FunctionCall(tok, type.AsIndDatatype.FullSanitizedName + "#Equal", Bpl.Type.Bool, e0, e1);
+      } else if (type.IsArrowType) {
+        return FunctionCall(tok, BuiltinFunction.FunEqual, null, e0, e1);
       } else {
         return Bpl.Expr.Eq(e0, e1);
       }
@@ -14953,7 +14955,7 @@ namespace Microsoft.Dafny {
                 var e1args = e.E1.Type.NormalizeExpand().TypeArgs;
                 return translator.CoEqualCall(cot, e0args, e1args, null, this.layerInterCluster.LayerN((int)FuelSetting.FuelAmount.HIGH), e0, e1, expr.tok);
               }
-              if (e.E0.Type.IsIndDatatype) {
+              if (e.E0.Type.IsIndDatatype || e.E0.Type.IsArrowType) {
                 return translator.TypeSpecificEqual(expr.tok, e.E0.Type, e0, e1);
               }
               typ = Bpl.Type.Bool;
@@ -16092,6 +16094,8 @@ namespace Microsoft.Dafny {
       IMapElements,
       IMapEqual,
       IMapGlue,
+      
+      FunEqual,
 
       IndexField,
       MultiIndexField,
@@ -16356,6 +16360,12 @@ namespace Microsoft.Dafny {
           Contract.Assert(args.Length == 1);
           Contract.Assert(typeInstantiation == null);
           return FunctionCall(tok, "$IsGoodMultiSet", Bpl.Type.Bool, args);
+        
+        case BuiltinFunction.FunEqual:
+          Contract.Assert(args.Length == 2);
+          Contract.Assert(typeInstantiation == null);
+          Expr heap = new Bpl.IdentifierExpr(tok, predef.HeapVarName, predef.HeapType);
+          return FunctionCall(tok, "Fun#Equal", Bpl.Type.Bool, args);
 
         case BuiltinFunction.SeqLength:
           Contract.Assert(args.Length == 1);

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8329,7 +8329,7 @@ namespace Microsoft.Dafny {
 
       {
         // forall p: [Heap, Box, ..., Box] Box, heap : Heap, b1, ..., bN : Box
-        //      :: ApplyN(HandleN(h, r, rd))[heap, b1, ..., bN] == h[heap, b1, ..., bN]
+        //      :: ApplyN(HandleN(h, r, rd))[heap, b1, ..., bN] == h[heap, b1, ..., bN] <== r[heap, b1, ..., bN]
         //      :: RequiresN(HandleN(h, r, rd))[heap, b1, ..., bN] <== r[heap, b1, ..., bN]
         //      :: ReadsN(HandleN(h, r, rd))[heap, b1, ..., bN] == rd[heap, b1, ..., bN]
         Action<ReqReadsApp, string> SelectorSemantics = (selector, selectorVar) => {
@@ -8359,6 +8359,11 @@ namespace Microsoft.Dafny {
           }
           if (selectorVar == "r") {
             op = (u, v) => Bpl.Expr.Imp(v, u);
+          }
+          if (selectorVar == "h") {
+            var req = new Bpl.NAryExpr(tok, new Bpl.MapSelect(tok, arity + 1),
+              Cons(new Bpl.IdentifierExpr(tok, "r", RraMapType(tok, arity, ReqReadsApp.Requires)), Cons(heap, boxes)));
+            op = (u, v) => Bpl.Expr.Imp(req, Bpl.Expr.Eq(u, v));
           }
           sink.AddTopLevelDeclaration(new Axiom(tok,
             BplForall(bvars, BplTrigger(lhs), op(lhs, rhs))));

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -8357,12 +8357,11 @@ namespace Microsoft.Dafny {
             var bx = BplBoundVar("bx", predef.BoxType, bvars);
             lhs = Bpl.Expr.SelectTok(tok, lhs, bx);
             rhs = Bpl.Expr.SelectTok(tok, rhs, bx);
-            // op = Bpl.Expr.Imp;
           }
           if (selectorVar == "r") {
             op = (u, v) => Bpl.Expr.Imp(v, u);
           }
-          if (selectorVar == "h") {
+          if (selectorVar == "h" || selectorVar == "rd") {
             var req = new Bpl.NAryExpr(tok, new Bpl.MapSelect(tok, arity + 1),
               Cons(new Bpl.IdentifierExpr(tok, "r", RraMapType(tok, arity, ReqReadsApp.Requires)), Cons(heap, boxes)));
             op = (u, v) => Bpl.Expr.Imp(req, Bpl.Expr.Eq(u, v));


### PR DESCRIPTION
## Overview
This PR adds functional extensionality (FE) axioms to Dafny. FE allows one to conclude that two functions `f` and `g` are equal if they are equal pointwise, i.e. if `forall x :: f(x) == g(x)`. 

The design of FE for Dafny was done jointly with @RustanLeino.

## How to use FE
Dafny will try to use function extensionality whenever two functions are compared for equality. In the following example `f` and `g` are pointwise equal:
```
var f := (x: int) => 2;
var g := (x: int) => 1 + 1;
```
Since the functions are not equal syntactically, to assert that they are equal we need function extensionality. In order to trigger the call of that axiom we need to explicity assert their equality:
```
assert f == g;
```
If Dafny can automatically prove that `forall x: int :: f(x) == g(x)` (which it can in this case) then the assertion will verify.

## How FE works
We translate equalities `f == g` between two functions into a special `Fun#Eq(f, g)` judgment. An axiom then states that `Fun#Eq` denotes equality of `f` and `g`:
```
forall f, g :: Fun#Eq(f, g) <==> f == g
```
The `Fun#Eq` function is there to trigger an automatic attempt to involve function extensionality. It would not be possible to trigger on function equality `f == g` because the SMT solver cannot trigger on its own built-in symbols such as `==`.

Functional extensionality is defined separately for functions of each arity. For example, for functions that take exacltly one argument FE is defined roughly as follows:
```
forall f, g ::
  if
    f and g don't read from the heap and
    forall x :: f.requires(x) == g.requires(x) and 
    forall x :: if f.requires(x) then f(x) == g(x)
  then Fun#Equal(f, g)
```
### Why functions that are compared for equality cannot read from the heap
Consider the following example in which `f` and `g` read an object `o` of type `bool` from the heap:
```
o := true;
var f = (x: int) reads o => if o then 1 else 2
var g = (x: int) reads o => if o then 1 else 3
assert f == g; // passes because for all x, f(x) == 1 == g(x)
o := false;
assert f == g; // passes even though now, for all x, f(x) == 2 != 3 == g(x)
```
The reason that the second equality assertion passes is that we have already proved that `f == g` and have not reassigned other values to `f` or `g` in between the two assertions. To avoid having to reason about the heap when comparing functions, we do not support FE for functions that have non-empty `reads` clauses.

## Todo
### Fix breaking test
Currently, the [`hofs/TreeMapSimple.dfy`](https://github.com/amaurremi/dafny/blob/27c54373cc3c72bdb09df3ac0cdbac2fd1cea8ea/Test/hofs/TreeMapSimple.dfy) test breaks. This happens due to Commit [40d69bd](https://github.com/dafny-lang/dafny/commit/40d69bd3a9cec140508b03502951a344a6503915) that changes `Apply` clauses to take `Requires` clauses into account.
### Test FE
  * Duplicate the [matrix-associativity](https://github.com/amaurremi/dafny/blob/funext/Test/lambdas/MatrixAssoc.dfy) and [state-monad](https://github.com/amaurremi/dafny/blob/funext/Test/lambdas/StateMonad.dfy) test cases and make them rely on the new built-in FE axioms rather than defining their own FE axiom in Dafny.
  * Experiment with other versions of the matrix-associativity proof:
    - to test FE for partial functions, use `requires` clauses instead of the `Index` type;
    - instead of currying represent matrix types as `(Index, Index) -> int`;
    - define matrix types as `int -> int -> int` and rewrite the proof to operate only on specific parts of the matrices.

### Improve support for total functions (interaction of FE and subtyping)

Boogie's `RequiresN` clause of a function is defined "indirectly" through the following axiom:
```
forall req, rd, f, x1, ..., xN, h ::
  req(f)[x1, ..., xN, h] ==>
  RequiresN(Handle(f, req, rd))[x1, ..., xN, h]
```
Here, `Handle(f, req, rd)` represents the anonymous function `f` with a requires clause `req` and a reads clause `rd`. Note that we do not know what`RequiresN` for this function and arguments is equal to, but merely that it is implied from `req(f)[x1, ..., xN, h]`.

This means that if we do not have direct access to a function `f`'s `requires` clause (e.g. if `f` is passed as a parameter to another function) then we cannot know whether
`RequiresN(f)[x1, ..., xN, h]` is equal to another function's requires clause for all inputs, and therefore we cannot satisfy one of the antecedents of the FE axiom. As a result, we can't compare `f` with other functions using FE.

What about total functions that do not *have* requires clauses? Should we be allowed to compare them for equality when these functions are passed as parameters? If we wanted to allow this we would need to reason about the `RequiresN` clause for those functions. One attempt would be to add an axiom that says that `RequiresN` is true for all arguments of the function's parameter types. For example, for functions of arity 1 this would look like this:
```
forall f ::
  if f is a total function of type A -> B
  forall x, heap ::
    Requires1(f)[x, heap] == x is of type A
```
However, this would be unsound since Dafny supports *subtyping*. Consider the following example:
```
lemma Unsound(f: nat -> int, g: nat -> int)
  requires forall x :: f(x) == g(x)
  ensures f == g
  { ... }
```
Now let's define two functions that are equal for all `nat` inputs but different for negative arguments:
```
var f := (x: int) => if x < 0 then 1 else 3;
var g := (x: int) => if x < 0 then 2 else 3;
```
Since `nat <: int`, the function type `(int -> int) <: (nat -> int)`, and therefore we can pass `f` and `g` as arguments to `Unsound`. If we could prove the `Unsound` lemma correct then we could conclude that `f` and `g` are equal, which they are not. Therefore one should not be able to prove `Unsound`. At the moment, we indeed should not be able to do so because we do not have access to `f`'s and `g`'s `RequiresN` clauses; if we did add the above axiom that states that `RequiresN` is equivalent to a typecheck of the arguments, the above proof would go through, causing unsoundness.
(todo: check that we indeed cannot prove that lemma)

However, perhaps we can allow such an axiom (that makes `RequiresN` for total functions equivalent to a typecheck) in the case where a function `f`'s parameter types are already the "largest" possible types (because then any concrete function that we would instantiate `f` with would not be have a strict subtype of `f`'s type, except in the return type).

We can identify the following types that do not have strict supertypes:
- base types (int, ...)
- datatypes that do not take type arguments
- codatatypes that do not take type arguments
- newtypes
- object?

We can add an axiom that the above types satisfy the property `IsTopType`, and add the following axiom which says that for functions that take such types as input, the requires clause is equivalent to a typecheck. For functions of arity 1:
```
forall f, T, U, x, heap ::
  if IsTopType(T) and f is a total function
  then Requires1(f)[heap, x] == x has type T
```
Note: we need to make sure that the `IsTopType` property is preserved if casts such as `g as int32 -> bool` are ever allowed in the future.